### PR TITLE
fix(json-validation): replace policy scopes enum values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ Inject processing report messages into request metrics for analytics.
 ^.^|X
 |Policy scope from where the policy is executed.
 ^.^|Policy scope
-|ON_REQUEST
+|REQUEST_CONTENT
 
 .^|errorMessage
 ^.^|X

--- a/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
@@ -26,7 +26,6 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
-import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
 import io.gravitee.gateway.api.http.stream.TransformableResponseStreamBuilder;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
@@ -69,8 +68,8 @@ public class JsonValidationPolicy {
 
     @OnRequestContent
     public ReadWriteStream onRequestContent(Request request, Response response, ExecutionContext executionContext, PolicyChain policyChain) {
-        if (configuration.getScope() == null || configuration.getScope() == PolicyScope.REQUEST) {
-            logger.debug("Execute json schema validation policy on request {}", request.id());
+        if (configuration.getScope() == null || configuration.getScope() == PolicyScope.REQUEST_CONTENT) {
+            logger.debug("Execute json schema validation policy on request content{}", request.id());
             return TransformableRequestStreamBuilder
                     .on(request)
                     .chain(policyChain)
@@ -100,7 +99,7 @@ public class JsonValidationPolicy {
 
     @OnResponseContent
     public ReadWriteStream onResponseContent(Request request, Response response, ExecutionContext executionContext, PolicyChain policyChain) {
-        if (configuration.getScope() == PolicyScope.RESPONSE) {
+        if (configuration.getScope() == PolicyScope.RESPONSE_CONTENT) {
             return TransformableResponseStreamBuilder
                     .on(response)
                     .chain(policyChain)

--- a/src/main/java/io/gravitee/policy/jsonvalidation/configuration/JsonValidationPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/configuration/JsonValidationPolicyConfiguration.java
@@ -16,12 +16,11 @@
 package io.gravitee.policy.jsonvalidation.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
-import io.gravitee.common.http.HttpMethod;
 
 @SuppressWarnings("unused")
 public class JsonValidationPolicyConfiguration implements PolicyConfiguration {
 
-    private PolicyScope scope = PolicyScope.REQUEST;
+    private PolicyScope scope = PolicyScope.REQUEST_CONTENT;
 
     private String errorMessage;
 

--- a/src/main/java/io/gravitee/policy/jsonvalidation/configuration/PolicyScope.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/configuration/PolicyScope.java
@@ -16,6 +16,6 @@
 package io.gravitee.policy.jsonvalidation.configuration;
 
 public enum PolicyScope {
-    REQUEST,
-    RESPONSE
+    REQUEST_CONTENT,
+    RESPONSE_CONTENT
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -4,10 +4,10 @@
   "properties" : {
     "scope" : {
       "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
+      "description": "Execute policy on <strong>request content</strong> or <strong>response content</strong> phase.",
       "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE" ],
+      "default": "REQUEST_CONTENT",
+      "enum" : [ "REQUEST_CONTENT", "RESPONSE_CONTENT" ],
       "deprecated": "true"
     },
     "errorMessage" : {

--- a/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
@@ -95,7 +95,7 @@ public class JsonValidationPolicyTest {
     @Test
     public void shouldAcceptValidPayload() {
         assertThatCode(() -> {
-            when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
             JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
             Buffer buffer = factory.buffer("{\"name\":\"foo\"}");
             ReadWriteStream readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -106,7 +106,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateRejectInvalidPayload() {
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
 
         Buffer buffer = factory.buffer("{\"name\":1}");
         ReadWriteStream readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -118,7 +118,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateUncheckedRejectInvalidPayload() {
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
 
         Buffer buffer = factory.buffer("{\"name\":1}");
         ReadWriteStream readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -130,7 +130,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldMalformedPayloadBeRejected() {
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
 
         Buffer buffer = factory.buffer("{\"name\":");
         ReadWriteStream readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -142,7 +142,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldMalformedJsonSchemaBeRejected() {
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
         when(configuration.getSchema()).thenReturn("\"msg\":\"error\"}");
 
         Buffer buffer = factory.buffer("{\"name\":\"foo\"}");
@@ -156,7 +156,7 @@ public class JsonValidationPolicyTest {
     @Test
     public void shouldAcceptValidResponsePayload() {
         assertThatCode(() -> {
-            when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+            when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
             JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
             Buffer buffer = factory.buffer("{\"name\":\"foo\"}");
             ReadWriteStream readWriteStream = policy.onResponseContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -167,7 +167,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateResponseInvalidPayload() {
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
 
         Buffer buffer = factory.buffer("{\"name\":1}");
         ReadWriteStream readWriteStream = policy.onResponseContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
@@ -179,7 +179,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateResponseInvalidSchema() {
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
         when(configuration.getSchema()).thenReturn("\"msg\":\"error\"}");
 
         Buffer buffer = factory.buffer("{\"name\":\"foo\"}");
@@ -192,7 +192,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateResponseInvalidPayloadStraightRespondMode() {
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
         when(configuration.isStraightRespondMode()).thenReturn(true);
 
         Buffer buffer = factory.buffer("{\"name\":1}");
@@ -205,7 +205,7 @@ public class JsonValidationPolicyTest {
 
     @Test
     public void shouldValidateResponseInvalidSchemaStraightRespondMode() {
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
         when(configuration.getSchema()).thenReturn("\"msg\":\"error\"}");
         when(configuration.isStraightRespondMode()).thenReturn(true);
 


### PR DESCRIPTION
Use REQUEST_CONTENT and RESPONSE_CONTENT instead of REQUEST and RESPONSE

Fixes gravitee-io/issues#4420