### PR TITLE
fix: stop propagating request to backend if not valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
         <swagger-parser.version>2.0.22</swagger-parser.version>
-        <mockito.version>3.5.13</mockito.version>
+        <mockito.version>4.4.0</mockito.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7301

**Description**

`TransformableReadWriteStream` will systematically do a call on write() and end() on the parent implementation when applying transformation method. It causes the chain to execute and propagate to backend even if we want to make the chain fail.

- Replace usage of `TransformableRequestStreamBuilder` by `BufferedReadWriteStream` to control if we have to `write()` and `end()` the stream. We continue the request only if json is valid
- Same for response, to be consistent. We continue the response if json is valid or invalid with `straightRespondMode` configuration set to true
- update mockito to 4.4.0 because of errors with java 17

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.1-issues-7301-stop-propagate-request-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/1.6.1-issues-7301-stop-propagate-request-SNAPSHOT/gravitee-policy-json-validation-1.6.1-issues-7301-stop-propagate-request-SNAPSHOT.zip)
  <!-- Version placeholder end -->
