### PR TITLE
fix: improve json-schema with V4 PolicyStudio

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:JsonValidationPolicyConfiguration",
+  "additionalProperties": false,
   "properties" : {
     "scope" : {
       "title": "Scope",
@@ -12,8 +13,14 @@
     },
     "errorMessage" : {
       "title": "Http error message",
-      "description": "Http error message to send when request is not valid. Status code is 400 as Bad request for REQUEST scope. Status code is 500 as Internal Error for RESPONSE scope (without straight respond mode).",
+      "description": "Http error message to send when request is not valid. Status code is 400 as Bad request for REQUEST scope. Status code is 500 as Internal Error for RESPONSE scope (without straight respond mode). e.g: {\"error\":\"Bad request\"}",
       "type" : "string",
+      "format": "gio-code-editor",
+      "gioConfig": {
+        "monacoEditorConfig": {
+          "language":"json"
+        }
+      },
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {
@@ -41,6 +48,12 @@
           "allowDropFileTypes": true,
           "autoCloseTags": true,
           "mode": "javascript"
+        }
+      },
+      "format": "gio-code-editor",
+      "gioConfig": {
+        "monacoEditorConfig": {
+          "language":"json"
         }
       }
     },


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-5328
gravitee-io/issues#9799

**Description**

After changes : 

![image](https://github.com/gravitee-io/gravitee-policy-json-validation/assets/4974420/d2da436c-31e2-4300-ac0e-d698ee3112fe)




**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.1-fix-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/1.7.1-fix-json-schema-SNAPSHOT/gravitee-policy-json-validation-1.7.1-fix-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
