### PR TITLE
JSON validation policy message not published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-apim.version>4.6.0-alpha.3</gravitee-apim.version>
         <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
-
+        <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
 
         <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
@@ -162,6 +162,12 @@
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
             <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.entrypoint</groupId>
+            <artifactId>gravitee-entrypoint-http-post</artifactId>
+            <version>${gravitee-entrypoint-http-post.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/gravitee/policy/JsonValidationException.java
+++ b/src/main/java/io/gravitee/policy/JsonValidationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy;
+
+public class JsonValidationException extends RuntimeException {
+
+    public JsonValidationException() {}
+
+    public JsonValidationException(String message) {
+        super(message);
+    }
+
+    public JsonValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public JsonValidationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyPublishIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyPublishIntegrationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jsonvalidation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MessageStorage;
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.PersistentMockEndpointConnectorFactory;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+@DeployApi({ "/apis/v4-validation.json" })
+@GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
+public class JsonValidationPolicyPublishIntegrationTest
+    extends AbstractPolicyTest<JsonValidationPolicy, JsonValidationPolicyConfiguration> {
+
+    static Stream<String> apis() {
+        return Stream.of("/a-v4-validation");
+    }
+
+    private MessageStorage messageStorage;
+
+    @BeforeEach
+    void setUp() {
+        messageStorage = getBean(MessageStorage.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        messageStorage.reset();
+    }
+
+    static Stream<TestCase> cases() {
+        return Stream.of(
+            new TestCase("good JSON object", JsonObject.of("message", "Turing"), false),
+            new TestCase("bad JSON object", JsonObject.of("no-user-field", "Turing"), true)
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> publishPhase(HttpClient client) {
+        return apis()
+            .flatMap(requestUri -> cases().map(testCase -> testCase.with(requestUri)))
+            .map(tuple ->
+                DynamicTest.dynamicTest(
+                    tuple.displayName(),
+                    () -> publishPhase(tuple.body(), tuple.entrypoint(), client, tuple.expectFail())
+                )
+            );
+    }
+
+    public void publishPhase(JsonObject body, String requestUri, HttpClient client, boolean expectFail) throws Exception {
+        postMessage(client, requestUri, body, Map.of("X-Test-Header", "header-value")).test().awaitDone(30, TimeUnit.SECONDS);
+        if (!expectFail) {
+            messageStorage
+                .subject()
+                .take(1)
+                .test()
+                .assertValue(message -> {
+                    assertThat(new JsonObject(message.content().toString())).isEqualTo(body);
+                    return true;
+                });
+        }
+    }
+
+    private Completable postMessage(HttpClient client, String requestURI, JsonObject requestBody, Map<String, String> headers) {
+        return client
+            .rxRequest(HttpMethod.POST, requestURI)
+            .flatMap(request -> {
+                headers.forEach(request::putHeader);
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapCompletable(response -> {
+                assertThat(response.statusCode()).isEqualTo(202);
+                return response.rxBody().ignoreElement();
+            });
+    }
+
+    record TestCase(String name, JsonObject body, boolean expectFail, String entrypoint) {
+        TestCase(String name, JsonObject body, boolean expectFail) {
+            this(name, body, expectFail, null);
+        }
+
+        TestCase with(String entrypoint) {
+            return new TestCase(name, body, expectFail, entrypoint);
+        }
+
+        String displayName() {
+            return "should %s with payload %s".formatted(expectFail ? "fail" : "success", name);
+        }
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        super.configureEndpoints(endpoints);
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", PersistentMockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("json-validation", PolicyBuilder.build("json-validation", JsonValidationPolicy.class));
+    }
+}

--- a/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
@@ -16,12 +16,12 @@
 package io.gravitee.policy.jsonvalidation;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.*;
+import io.gravitee.gateway.reactive.api.message.DefaultMessage;
+import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -108,7 +110,84 @@ class JsonValidationPolicyTest {
     }
 
     @Nested
-    class OnResponseTest {}
+    class OnMessageRequestTest {
+
+        @Mock
+        HttpMessageExecutionContext ctx;
+
+        @Mock
+        HttpMessageRequest request;
+
+        @Captor
+        ArgumentCaptor<java.util.function.Function<Message, Maybe<Message>>> messageCaptor;
+
+        @BeforeEach
+        void setUp() {
+            when(ctx.request()).thenReturn(request);
+            when(request.onMessage(any())).thenReturn(Completable.complete());
+        }
+
+        @Test
+        void testOnMessageRequest_validationSucceeds() throws IOException {
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer("{\"name\":\"foo\"}")).build();
+            policy.onMessageRequest(ctx).test().assertComplete();
+            verify(request).onMessage(messageCaptor.capture());
+            messageCaptor.getValue().apply(message).test().assertValue(message);
+        }
+
+        @Test
+        void testOnMessageRequest_validationFails() throws IOException {
+            var metrics = Metrics.builder().build();
+            lenient().when(ctx.metrics()).thenReturn(metrics);
+            when(ctx.interruptMessageWith(any())).thenReturn(Maybe.error(new MyCustomException()));
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer("{\"name2\":\"foo\"}")).build();
+            policy.onMessageRequest(ctx).test().assertComplete();
+            verify(request).onMessage(messageCaptor.capture());
+            messageCaptor.getValue().apply(message).test().assertError(throwable -> throwable instanceof MyCustomException);
+        }
+    }
+
+    @Nested
+    class OnMessageResponseTest {
+
+        @Mock
+        HttpMessageExecutionContext ctx;
+
+        @Mock
+        HttpMessageResponse response;
+
+        @Captor
+        ArgumentCaptor<java.util.function.Function<Message, Maybe<Message>>> messageCaptor;
+
+        @BeforeEach
+        void setUp() {
+            when(ctx.response()).thenReturn(response);
+            lenient().when(response.onMessage(any())).thenReturn(Completable.complete());
+        }
+
+        @Test
+        void testOnMessageReesponse_validationSucceeds() throws IOException {
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer("{\"name\":\"foo\"}")).build();
+            policy.onMessageResponse(ctx).test().assertComplete();
+            verify(response).onMessage(messageCaptor.capture());
+            messageCaptor.getValue().apply(message).test().assertValue(message);
+        }
+
+        @Test
+        void testOnMessageReesponse_validationFails() throws IOException {
+            var metrics = Metrics.builder().build();
+            lenient().when(ctx.metrics()).thenReturn(metrics);
+            lenient().when(ctx.interruptMessageWith(any())).thenReturn(Maybe.error(new MyCustomException()));
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer("{\"name2\":\"foo\"}")).build();
+            policy.onMessageResponse(ctx).test().assertComplete();
+            verify(response).onMessage(messageCaptor.capture());
+            messageCaptor.getValue().apply(message).test().assertError(throwable -> throwable instanceof MyCustomException);
+        }
+    }
 
     private static class MyCustomException extends RuntimeException {}
 }

--- a/src/test/resources/apis/v4-validation.json
+++ b/src/test/resources/apis/v4-validation.json
@@ -1,0 +1,68 @@
+{
+    "id": "a-v4-validation",
+    "name": "a-v4-validation",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "message",
+    "analytics": {},
+    "description": "a-v4-api",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/a-v4-validation"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-post"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "mock",
+            "endpoints": [
+                {
+                    "name": "default-endpoint",
+                    "type": "mock",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {}
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [],
+            "response": [],
+            "subscribe": [],
+            "publish": [
+                {
+                    "name": "Json validation",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"title\": \"Message\",\n  \"description\": \"Policy to demonstrate bug\",\n  \"properties\": {\n    \"message\": {\n      \"type\": \"string\"\n    }\n  },\n  \"required\": [\n    \"message\"\n  ]\n}",
+                        "scope": "REQUEST_CONTENT",
+                        "errorMessage": "{\n    \"message\": \"Invalid format of your message\",\n    \"http_status_code\": 400\n}"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8571

**Description**

Changed onMessageRequest method to use filter
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.3-APIM-8571-JSON-validation-policy-causes-the-message-not-to-be-published-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.0.3-APIM-8571-JSON-validation-policy-causes-the-message-not-to-be-published-SNAPSHOT/gravitee-policy-json-validation-2.0.3-APIM-8571-JSON-validation-policy-causes-the-message-not-to-be-published-SNAPSHOT.zip)
  <!-- Version placeholder end -->
