### PR TITLE
fix(deps): Excluding jackson-core deps to fix security vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.17.0
+    gravitee: gravitee-io/gravitee@4.18.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,30 @@
                     <artifactId>rhino</artifactId>
                     <groupId>org.mozilla</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>   
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>    
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13243

**Description**

Excluding jackson-core deps to fix security vulnerabilities. 

**Additional context**

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.2-fix-apim-13243-main-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.1.2-fix-apim-13243-main-SNAPSHOT/gravitee-policy-json-validation-2.1.2-fix-apim-13243-main-SNAPSHOT.zip)
  <!-- Version placeholder end -->
