### PR TITLE
fix: bump APIM version to 4.10.14 for rhino 1.7.15.1 (CVE-2025-66453)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.24</gravitee-apim.version>
+        <gravitee-apim.version>4.10.14</gravitee-apim.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-schema-registry-provider-api.version>1.0.1</gravitee-resource-schema-registry-provider-api.version>
-        <gravitee-reactor-message.version>5.0.2</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>9.0.1</gravitee-reactor-message.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
 
@@ -155,12 +155,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.apim.gateway</groupId>
-            <artifactId>gravitee-apim-gateway-buffer</artifactId>
-            <version>${gravitee-apim.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>

--- a/src/test/java/io/gravitee/policy/jsonvalidation/kafka/factory/TestKafkaApiMessageFactory.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/kafka/factory/TestKafkaApiMessageFactory.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.policy.jsonvalidation.kafka.factory;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
@@ -68,7 +68,7 @@ public class TestKafkaApiMessageFactory {
     private static FetchResponseData.PartitionData createPartitionDataWithRecord(int partitionIndex) {
         MemoryRecords records = MemoryRecords.withRecords(
             RecordBatch.CURRENT_MAGIC_VALUE,
-            CompressionType.NONE,
+            Compression.NONE,
             new SimpleRecord("key".getBytes(), "value".getBytes())
         );
 

--- a/src/test/java/io/gravitee/policy/jsonvalidation/kafka/stub/KafkaMessageStub.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/kafka/stub/KafkaMessageStub.java
@@ -63,6 +63,21 @@ public class KafkaMessageStub implements KafkaMessage {
     }
 
     @Override
+    public KafkaMessage key(Buffer key) {
+        return this;
+    }
+
+    @Override
+    public KafkaMessage key(String key) {
+        return this;
+    }
+
+    @Override
+    public int sizeInBytes() {
+        return content == null ? 0 : content.length();
+    }
+
+    @Override
     public long offset() {
         return 0;
     }


### PR DESCRIPTION
## Summary
- Bump `gravitee-apim.version` 4.6.24 → 4.10.14 so the plugin assembly bundles `rhino 1.7.15.1` instead of the vulnerable `1.7.15` (CVE-2025-66453, ReDoS via `toFixed()`).
- Bump `gravitee-reactor-message` test dep 5.0.2 → 9.0.1 to match the APIM 4.10.x reactor SPI / Spring bootstrap lifecycle.
- Drop the explicit `gravitee-apim-gateway-buffer` test dep — module is no longer published from 4.10.x; `BufferFactory` SPI now comes transitively via `gravitee-apim-gateway-tests-sdk`.
- Adapt `KafkaMessageStub` for the three new abstract methods on `KafkaMessage` (`sizeInBytes`, `key(Buffer)`, `key(String)`); adapt `TestKafkaApiMessageFactory` for the kafka-clients `Compression` API refactor.

Refs [APIM-14150](https://gravitee.atlassian.net/browse/APIM-14150).

## Test plan
- [x] `mvn dependency:tree -Dincludes=org.mozilla:rhino` resolves to `1.7.15.1`
- [x] `mvn verify` green locally (53 tests, 0 errors, 0 failures)
- [x] Assembled `target/gravitee-policy-json-validation-2.2.0-alpha.2.zip` contains `lib/rhino-1.7.15.1.jar`
- [x] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APIM-14150]: https://gravitee.atlassian.net/browse/APIM-14150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-apim-14150-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.2.0-apim-14150-SNAPSHOT/gravitee-policy-json-validation-2.2.0-apim-14150-SNAPSHOT.zip)
  <!-- Version placeholder end -->
