### PR TITLE
Bump rhino version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
 
-        <maven-plugin-assembly.version>3.8.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>
 
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
@@ -239,7 +238,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <gravitee-reactor-message.version>5.0.2</gravitee-reactor-message.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
+        <rhino.version>1.7.15.1</rhino.version>
 
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>
 
@@ -119,7 +120,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <scope>provided</scope>
+            <version>${rhino.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13564

**Description**

use 4.8.27 of apim to have latest version of rhino lib
put back compile scope of the library so. the plugin embeds it in the final zip file.
indeed the rhino lib is not provided by the gateway container
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.4-bump-rhino-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.1.4-bump-rhino-version-SNAPSHOT/gravitee-policy-json-validation-2.1.4-bump-rhino-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
