### PR TITLE
perf: parse static JSON schema once instead of on every request

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,34 @@ spec:
 
 ## Changelog
 
+#### [2.1.4](https://github.com/gravitee-io/gravitee-policy-json-validation/compare/2.1.3...2.1.4) (2026-05-29)
+
+
+##### Bug Fixes
+
+* force version of rhino ([aeaac0e](https://github.com/gravitee-io/gravitee-policy-json-validation/commit/aeaac0e63b4b0eff03d53d748824916029256939))
+
+#### [2.1.3](https://github.com/gravitee-io/gravitee-policy-json-validation/compare/2.1.2...2.1.3) (2026-05-29)
+
+
+##### Bug Fixes
+
+* **deps:** change rhino scope ([#72](https://github.com/gravitee-io/gravitee-policy-json-validation/issues/72)) ([95662f0](https://github.com/gravitee-io/gravitee-policy-json-validation/commit/95662f0cc0fee1eddb2e88027b9710293c6014db))
+
+#### [2.1.2](https://github.com/gravitee-io/gravitee-policy-json-validation/compare/2.1.1...2.1.2) (2026-05-21)
+
+
+##### Bug Fixes
+
+* **deps:** Excluding jackson-core deps to fix security vulnerabilities ([67e75dd](https://github.com/gravitee-io/gravitee-policy-json-validation/commit/67e75dd12d15e8d97d736778ae34c3271a6298b0))
+
+#### [2.1.1](https://github.com/gravitee-io/gravitee-policy-json-validation/compare/2.1.0...2.1.1) (2026-03-11)
+
+
+##### Bug Fixes
+
+* improve JSON validation error handling ([67306e0](https://github.com/gravitee-io/gravitee-policy-json-validation/commit/67306e07eac0aeef38c99569b735cecd922de200))
+
 ### [2.1.0](https://github.com/gravitee-io/gravitee-policy-json-validation/compare/2.0.3...2.1.0) (2025-11-13)
 
 

--- a/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
@@ -42,6 +42,7 @@ import io.gravitee.policy.jsonvalidation.configuration.errorhandling.NativeError
 import io.gravitee.policy.jsonvalidation.handler.ValidationResultHandler;
 import io.gravitee.policy.jsonvalidation.handler.kafka.KafkaValidationResultHandler;
 import io.gravitee.policy.jsonvalidation.schema.SchemaResolver;
+import io.gravitee.policy.jsonvalidation.schema.StaticSchema;
 import io.gravitee.policy.jsonvalidation.schema.ValidatableSchemaResolver;
 import io.gravitee.policy.v3.jsonvalidation.JsonValidationPolicyV3;
 import io.gravitee.resource.schema_registry.api.Schema;
@@ -219,7 +220,7 @@ public class JsonValidationPolicy extends JsonValidationPolicyV3 implements Http
         boolean straightMode,
         BiFunction<T, ExecutionFailure, Completable> interrupt
     ) throws IOException, ProcessingException {
-        var parsedSchema = JsonLoader.fromString(schema.getContent());
+        var parsedSchema = parseSchema(schema);
         var jsonNode = JSON_MAPPER.readTree(buffer.getBytes());
 
         var report = validatePayload(parsedSchema, jsonNode);
@@ -265,9 +266,18 @@ public class JsonValidationPolicy extends JsonValidationPolicyV3 implements Http
     }
 
     private ProcessingReport validatePayload(Buffer buffer, Schema schema) throws IOException, ProcessingException {
-        JsonNode parsedSchema = JsonLoader.fromString(schema.getContent());
+        JsonNode parsedSchema = parseSchema(schema);
         JsonNode jsonNode = JSON_MAPPER.readTree(buffer.getBytes());
         return validatePayload(parsedSchema, jsonNode);
+    }
+
+    // Parse the schema, reusing the parsed JsonNode for static schemas (parsed once, immutable per policy
+    // instance). Registry-resolved schemas are parsed per request since their content may change.
+    private static JsonNode parseSchema(Schema schema) throws IOException {
+        if (schema instanceof StaticSchema staticSchema) {
+            return staticSchema.parsedSchema();
+        }
+        return JsonLoader.fromString(schema.getContent());
     }
 
     // callers always supply pre-parsed nodes — validate() and validatePayload(Buffer,Schema) handle Buffer→JsonNode conversion

--- a/src/main/java/io/gravitee/policy/jsonvalidation/schema/StaticSchema.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/schema/StaticSchema.java
@@ -36,8 +36,7 @@ public class StaticSchema implements Schema {
 
     private final String content;
 
-    // Parsed once and reused across requests (the static schema is immutable per policy instance),
-    // mirroring InlineSchemaProvider in the Avro transform policies. Registry schemas are parsed per request.
+    // Parsed once and reused across requests (the static schema is immutable per policy instance).
     private volatile JsonNode parsedSchema;
 
     @Override
@@ -77,6 +76,9 @@ public class StaticSchema implements Schema {
                 local = parsedSchema;
                 if (local == null) {
                     local = JsonLoader.fromString(content);
+                    if (local == null || local.isMissingNode()) {
+                        throw new IOException("Configured JSON schema is empty or could not be parsed");
+                    }
                     parsedSchema = local;
                 }
             }

--- a/src/main/java/io/gravitee/policy/jsonvalidation/schema/StaticSchema.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/schema/StaticSchema.java
@@ -15,8 +15,11 @@
  */
 package io.gravitee.policy.jsonvalidation.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jackson.JsonLoader;
 import io.gravitee.resource.schema_registry.api.Reference;
 import io.gravitee.resource.schema_registry.api.Schema;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,10 @@ public class StaticSchema implements Schema {
     private static final String STATIC_SCHEMA_VERSION = "1";
 
     private final String content;
+
+    // Parsed once and reused across requests (the static schema is immutable per policy instance),
+    // mirroring InlineSchemaProvider in the Avro transform policies. Registry schemas are parsed per request.
+    private volatile JsonNode parsedSchema;
 
     @Override
     public String getContent() {
@@ -61,5 +68,19 @@ public class StaticSchema implements Schema {
     @Override
     public Map<String, String> getDependencies() {
         return Map.of();
+    }
+
+    public JsonNode parsedSchema() throws IOException {
+        JsonNode local = parsedSchema;
+        if (local == null) {
+            synchronized (this) {
+                local = parsedSchema;
+                if (local == null) {
+                    local = JsonLoader.fromString(content);
+                    parsedSchema = local;
+                }
+            }
+        }
+        return local;
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
@@ -71,6 +71,9 @@ public class JsonValidationPolicyV3 {
 
     protected static final JsonValidator validator = JsonSchemaFactory.byDefault().getValidator();
 
+    // The legacy schema is fixed per policy instance; parse it once and reuse it across requests.
+    private volatile JsonNode legacyParsedSchema;
+
     /**
      * Create a new JsonMetadata Policy instance based on its associated configuration
      *
@@ -220,9 +223,6 @@ public class JsonValidationPolicyV3 {
     }
 
     @SuppressWarnings("deprecation")
-    // The legacy schema is fixed per policy instance; parse it once and reuse it across requests.
-    private volatile JsonNode legacyParsedSchema;
-
     private JsonNode resolveLegacySchema(Request request, Response response, ExecutionContext executionContext) throws IOException {
         JsonNode cached = legacyParsedSchema;
         if (cached != null) {
@@ -246,7 +246,11 @@ public class JsonValidationPolicyV3 {
         }
         synchronized (this) {
             if (legacyParsedSchema == null) {
-                legacyParsedSchema = JsonLoader.fromString(schemaContent);
+                JsonNode parsed = JsonLoader.fromString(schemaContent);
+                if (parsed == null || parsed.isMissingNode()) {
+                    throw new IOException("Configured JSON schema is empty or could not be parsed");
+                }
+                legacyParsedSchema = parsed;
             }
             return legacyParsedSchema;
         }

--- a/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
@@ -220,7 +220,14 @@ public class JsonValidationPolicyV3 {
     }
 
     @SuppressWarnings("deprecation")
+    // The legacy schema is fixed per policy instance; parse it once and reuse it across requests.
+    private volatile JsonNode legacyParsedSchema;
+
     private JsonNode resolveLegacySchema(Request request, Response response, ExecutionContext executionContext) throws IOException {
+        JsonNode cached = legacyParsedSchema;
+        if (cached != null) {
+            return cached;
+        }
         String schemaContent = configuration.getSchema();
         // The deprecated `schema` field may be null when the policy is configured with the newer
         // `schemaSource` form. The V3 engine only supports a static schema; registry sources are V4-only.
@@ -237,7 +244,12 @@ public class JsonValidationPolicyV3 {
         if (schemaContent == null) {
             throw new IllegalStateException("No JSON schema configured in the policy");
         }
-        return JsonLoader.fromString(schemaContent);
+        synchronized (this) {
+            if (legacyParsedSchema == null) {
+                legacyParsedSchema = JsonLoader.fromString(schemaContent);
+            }
+            return legacyParsedSchema;
+        }
     }
 
     private record ErrorParams(String payloadKeyError, String formatKeyError, int errorStatus) {}

--- a/src/test/java/io/gravitee/policy/jsonvalidation/schema/StaticSchemaTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/schema/StaticSchemaTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jsonvalidation.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class StaticSchemaTest {
+
+    private static final String SCHEMA = "{\"type\":\"object\"}";
+
+    @Test
+    void should_parse_static_schema_once_and_reuse_it() throws IOException {
+        StaticSchema staticSchema = new StaticSchema(SCHEMA);
+
+        JsonNode first = staticSchema.parsedSchema();
+        JsonNode second = staticSchema.parsedSchema();
+
+        // Same instance is returned: the schema is parsed once and cached (no per-request re-parsing).
+        assertSame(first, second);
+        assertEquals("object", first.get("type").asText());
+    }
+}


### PR DESCRIPTION
## Issue

N/A — performance improvement (no Jira ticket).

## Description

The policy currently re-parses the JSON schema string on **every** request (`JsonLoader.fromString(schema.getContent())`), which adds CPU overhead and prevents the underlying `json-schema-validator` from reusing compiled schemas.

A static schema is immutable for the lifetime of a policy instance, so it can be parsed **once** and reused — the same approach already used by the Avro transform policies (`InlineSchemaProvider` parses the schema in its constructor and reuses it).

Changes:
- `StaticSchema#parsedSchema()` parses the schema once (lazy, thread-safe) and caches the `JsonNode`.
- `JsonValidationPolicy#parseSchema(Schema)` returns the cached node for static schemas; **registry-resolved schemas keep being parsed per request** since their content may change (consistent with the Avro `RegistrySchemaProvider`).
- The V3 legacy path caches its parsed schema as well (it is fixed per policy instance).
- Added `StaticSchemaTest` asserting the schema is parsed once and reused (`assertSame`).

This addresses the schema-caching review comments on #80, but avoids caching by `schema.getId()` (which is a constant for static schemas and would risk serving stale schemas for registry sources).

## Additional context

Targets `alpha`. No behavioural change; `mvn clean verify` passes (114 tests).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-feat-cache-parsed-static-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/3.0.0-feat-cache-parsed-static-schema-SNAPSHOT/gravitee-policy-json-validation-3.0.0-feat-cache-parsed-static-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
