### PR TITLE
docs: add 3.x compatibility row to version matrix

### DIFF
--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -5,3 +5,6 @@ rows:
     - data:
           plugin: "2.x"
           apim: "4.6 and greater"
+    - data:
+          plugin: "3.x"
+          apim: "4.12 and greater"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Strikethrough text indicates that a version is deprecated.
 | --- | ---  |
 |1.x|4.5 and lower |
 |2.x|4.6 and greater |
+|3.x|4.12 and greater |
 
 
 ## Configuration options


### PR DESCRIPTION
## Purpose

The version compatibility matrix was missing an entry for the 3.x plugin series (compatible with APIM 4.12 and greater). This adds the row so users and the CI doc-gen check have accurate compatibility information.

## Summary of changes

- `.docgen/matrix.yaml`: added `3.x / 4.12 and greater` row.
- `README.md`: regenerated via doc-gen to reflect the new matrix row.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/3.0.0/gravitee-policy-json-validation-3.0.0.zip)
  <!-- Version placeholder end -->
