### PR TITLE
feat: add returnDetailedErrorReport flag to surface per-violation detail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.18.0
+    gravitee: gravitee-io/gravitee@5.5.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.claude/
+.m2-repo/
+.worktrees/
+target/
+node_modules/

--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,13 @@ It can inject processing report messages into request metrics for analytics.
 
 .^|straightRespondMode
 ^.^|
-|Only for RESPONSE scope. Straight respond mode means that responses failed to validate still will be sent to user without replacement. Validation failures messages are still being written to the metrics for further inspection.
+|Only for RESPONSE scope. When enabled, responses that fail validation are still forwarded to the client unchanged. Validation failures are recorded in the metrics for further inspection.
+^.^|boolean
+^.^|false
+
+.^|returnDetailedErrorReport
+^.^|
+|When enabled, the error response body returns a per-violation detail string (JSON pointer + reason) instead of the configured errorMessage; SpEL is not evaluated. Warning: exposes schema structure to callers, disable in production unless trusted.
 ^.^|boolean
 ^.^|false
 

--- a/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicy.java
@@ -150,12 +150,24 @@ public class JsonValidationPolicy extends JsonValidationPolicyV3 implements Http
         var report = configuration.isValidateUnchecked()
             ? validator.validateUnchecked(schema, jsonNode)
             : validator.validate(schema, jsonNode);
-        if (!report.isSuccess()) {
-            log.debug("Invalid body '{}'", report);
+        if (report.isSuccess()) {
+            return Completable.complete();
         }
-        return report.isSuccess()
-            ? Completable.complete()
-            : errorHandling(ctx, report.toString(), source.status, source.getPayloadKey(), straightMode, interrupt);
+        log.debug("Invalid body '{}'", report);
+
+        // straightMode is only ever true for the HTTP RESPONSE scope (configuration.isStraightRespondMode())
+        // and the message scopes (straightRespond field); REQUEST always passes false, so this guard
+        // cannot suppress validation detail for the request scope.
+        String detailedMessage = null;
+        if (configuration.isReturnDetailedErrorReport() && !straightMode) {
+            try {
+                detailedMessage = buildDetailedMessage(schema, jsonNode).orElse(null);
+            } catch (RuntimeException ex) {
+                log.error("Unexpected error during JSON validation", ex);
+            }
+        }
+
+        return errorHandling(ctx, report.toString(), source.status, source.getPayloadKey(), straightMode, detailedMessage, interrupt);
     }
 
     private <T extends HttpBaseExecutionContext> Completable errorHandling(
@@ -169,7 +181,7 @@ public class JsonValidationPolicy extends JsonValidationPolicyV3 implements Http
             ? source.getPayloadKey()
             : source.getFormatKey();
         String message = th.getMessage() != null ? th.getMessage() : "Unknown error";
-        return errorHandling(ctx, message, source.status, key, straightMode, interrupt);
+        return errorHandling(ctx, message, source.status, key, straightMode, null, interrupt);
     }
 
     private <T extends HttpBaseExecutionContext> Completable errorHandling(
@@ -178,20 +190,29 @@ public class JsonValidationPolicy extends JsonValidationPolicyV3 implements Http
         int statusCode,
         String key,
         boolean straightMode,
+        String detailedMessage,
         BiFunction<T, ExecutionFailure, Completable> interrupt
     ) {
         ctx.metrics().setErrorMessage(th);
-        return straightMode
-            ? Completable.complete()
-            : errorMessage(ctx, statusCode).flatMapCompletable(msg ->
-                interrupt.apply(ctx, new ExecutionFailure(statusCode).contentType(MediaType.APPLICATION_JSON).key(key).message(msg))
-            );
+        if (straightMode) {
+            return Completable.complete();
+        }
+        var message = detailedMessage != null ? Maybe.just(detailedMessage) : errorMessage(ctx, statusCode);
+        return message.flatMapCompletable(msg ->
+            interrupt.apply(ctx, new ExecutionFailure(statusCode).contentType(MediaType.TEXT_PLAIN).key(key).message(msg))
+        );
     }
 
     private Maybe<String> errorMessage(HttpBaseExecutionContext executionContext, int httpStatusCode) {
         String defaultMessage = httpStatusCode == 400 ? BAD_REQUEST : INTERNAL_ERROR;
         return configuration.getErrorMessage() != null && !configuration.getErrorMessage().isEmpty()
-            ? executionContext.getTemplateEngine().eval(configuration.getErrorMessage(), String.class)
+            ? executionContext
+                .getTemplateEngine()
+                .eval(configuration.getErrorMessage(), String.class)
+                .onErrorResumeNext(e -> {
+                    log.warn("Failed to evaluate error message expression, falling back to default message: {}", e.getMessage());
+                    return Maybe.just(defaultMessage);
+                })
             : Maybe.just(defaultMessage);
     }
 

--- a/src/main/java/io/gravitee/policy/jsonvalidation/configuration/JsonValidationPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jsonvalidation/configuration/JsonValidationPolicyConfiguration.java
@@ -32,6 +32,8 @@ public class JsonValidationPolicyConfiguration implements PolicyConfiguration {
 
     private boolean straightRespondMode;
 
+    private boolean returnDetailedErrorReport;
+
     public PolicyScope getScope() {
         return scope;
     }
@@ -78,5 +80,13 @@ public class JsonValidationPolicyConfiguration implements PolicyConfiguration {
 
     public void setStraightRespondMode(boolean straightRespondMode) {
         this.straightRespondMode = straightRespondMode;
+    }
+
+    public boolean isReturnDetailedErrorReport() {
+        return returnDetailedErrorReport;
+    }
+
+    public void setReturnDetailedErrorReport(boolean returnDetailedErrorReport) {
+        this.returnDetailedErrorReport = returnDetailedErrorReport;
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.v3.jsonvalidation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import com.github.fge.jsonschema.main.JsonValidator;
@@ -33,6 +34,8 @@ import io.gravitee.policy.api.annotations.OnRequestContent;
 import io.gravitee.policy.api.annotations.OnResponseContent;
 import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
 import io.gravitee.policy.jsonvalidation.configuration.PolicyScope;
+import java.util.LinkedHashSet;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +127,10 @@ public class JsonValidationPolicyV3 {
                 if (!report.isSuccess()) {
                     request.metrics().setMessage(report.toString());
                     if (!straightMode) {
-                        sendErrorResponse(errorParams.payloadKeyError(), executionContext, policyChain, errorParams.errorStatus());
+                        String detail = configuration.isReturnDetailedErrorReport()
+                            ? buildDetailedMessage(schema, content).orElse(null)
+                            : null;
+                        sendErrorResponse(errorParams.payloadKeyError(), executionContext, policyChain, errorParams.errorStatus(), detail);
                     } else {
                         // In Straight Respond Mode, send the response to the user without replacement.
                         writeBufferAndEnd.run();
@@ -135,14 +141,17 @@ public class JsonValidationPolicyV3 {
             } catch (ProcessingException ex) {
                 request.metrics().setMessage(ex.toString());
                 if (!straightMode) {
-                    sendErrorResponse(errorParams.payloadKeyError(), executionContext, policyChain, errorParams.errorStatus());
+                    sendErrorResponse(errorParams.payloadKeyError(), executionContext, policyChain, errorParams.errorStatus(), null);
                 } else {
                     writeBufferAndEnd.run();
                 }
             } catch (Exception ex) {
+                if (ex instanceof RuntimeException) {
+                    logger.error("Unexpected error during JSON validation", ex);
+                }
                 request.metrics().setMessage(ex.toString());
                 if (!straightMode) {
-                    sendErrorResponse(errorParams.formatKeyError(), executionContext, policyChain, errorParams.errorStatus());
+                    sendErrorResponse(errorParams.formatKeyError(), executionContext, policyChain, errorParams.errorStatus(), null);
                 } else {
                     writeBufferAndEnd.run();
                 }
@@ -158,17 +167,59 @@ public class JsonValidationPolicyV3 {
         }
     }
 
-    private void sendErrorResponse(String key, ExecutionContext executionContext, PolicyChain policyChain, int httpStatusCode) {
-        if (configuration.getErrorMessage() != null && !configuration.getErrorMessage().isEmpty()) {
+    private void sendErrorResponse(
+        String key,
+        ExecutionContext executionContext,
+        PolicyChain policyChain,
+        int httpStatusCode,
+        String detail
+    ) {
+        String configuredMessage = configuration.getErrorMessage();
+        boolean hasConfiguredMessage = configuredMessage != null && !configuredMessage.isEmpty();
+        if (detail != null) {
+            policyChain.streamFailWith(PolicyResult.failure(key, httpStatusCode, detail, MediaType.TEXT_PLAIN));
+        } else if (hasConfiguredMessage) {
             executionContext
                 .getTemplateEngine()
-                .eval(configuration.getErrorMessage(), String.class)
-                .subscribe(errorMessage ->
-                    policyChain.streamFailWith(PolicyResult.failure(key, httpStatusCode, errorMessage, MediaType.APPLICATION_JSON))
+                .eval(configuredMessage, String.class)
+                .subscribe(
+                    errorMessage ->
+                        policyChain.streamFailWith(PolicyResult.failure(key, httpStatusCode, errorMessage, MediaType.TEXT_PLAIN)),
+                    throwable -> {
+                        logger.warn("Error message evaluation failed: {}", throwable.getMessage(), throwable);
+                        String fallbackMessage = httpStatusCode == 400 ? BAD_REQUEST : INTERNAL_ERROR;
+                        policyChain.streamFailWith(PolicyResult.failure(key, httpStatusCode, fallbackMessage, MediaType.TEXT_PLAIN));
+                    }
                 );
         } else {
             String errorMessage = httpStatusCode == 400 ? BAD_REQUEST : INTERNAL_ERROR;
             policyChain.streamFailWith(PolicyResult.failure(key, httpStatusCode, errorMessage, MediaType.TEXT_PLAIN));
+        }
+    }
+
+    protected Optional<String> buildDetailedMessage(JsonNode schema, JsonNode content) {
+        try {
+            ProcessingReport deepReport = configuration.isValidateUnchecked()
+                ? validator.validateUnchecked(schema, content, true)
+                : validator.validate(schema, content, true);
+
+            var details = new LinkedHashSet<String>();
+            int count = 0;
+            for (ProcessingMessage processingMessage : deepReport) {
+                if (count >= 50) {
+                    break;
+                }
+                var json = processingMessage.asJson();
+                var pointer = json.path("instance").path("pointer").asText();
+                var label = pointer.isBlank() ? "(root)" : pointer;
+                var message = json.path("message").asText();
+                details.add(label + " — " + message);
+                count++;
+            }
+            return Optional.of(String.join("; ", details)).filter(s -> !s.isBlank());
+        } catch (ProcessingException ex) {
+            logger.warn("Detailed validation report generation failed: {}", ex.getMessage(), ex);
+            return Optional.empty();
         }
     }
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -69,8 +69,14 @@
         },
         "straightRespondMode": {
             "title": "Straight respond mode",
-            "description": "Only for RESPONSE scope. Straight respond mode means that responses failed to validate still will be sent to user without replacement. Validation failures messages are still being written to the metrics for further inspection.",
+            "description": "Only for RESPONSE scope. When enabled, responses that fail validation are still forwarded to the client unchanged. Validation failures are recorded in the metrics for further inspection.",
             "type": "boolean"
+        },
+        "returnDetailedErrorReport": {
+            "title": "Return detailed error report",
+            "description": "Return per-field JSON Schema validation detail in the error response instead of the generic error message. Warning: exposes schema structure to callers — disable in production unless callers are trusted.",
+            "type": "boolean",
+            "default": false
         }
     },
     "required": ["schema"]

--- a/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationDetailedErrorReportIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationDetailedErrorReportIntegrationTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jsonvalidation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.vertx.core.http.HttpMethod.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@DeployApi(
+    {
+        "/apis/v4-detailed-request.json",
+        "/apis/v4-detailed-request-code.json",
+        "/apis/v4-detailed-per-instance.json",
+        "/apis/v4-detailed-response.json",
+        "/apis/v4-straight-respond-flag-on.json",
+        "/apis/v4-straight-respond-flag-off.json",
+    }
+)
+@GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
+public class JsonValidationDetailedErrorReportIntegrationTest
+    extends AbstractPolicyTest<JsonValidationPolicy, JsonValidationPolicyConfiguration> {
+
+    private static final String AGE_VIOLATION =
+        "/age — instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])";
+    private static final String EMAIL_VIOLATION = "/email — string \"x\" is too short (length: 1, required minimum: 5)";
+    private static final String CODE_TOO_LONG_VIOLATION = "string \"${T(java.lang.Runtime)}\" is too long (length: 23, maximum allowed: 3)";
+
+    private static final String VALID_BODY = "{\"name\":\"Ada\",\"age\":2,\"email\":\"ada@x.io\"}";
+    private static final String INVALID_TYPE_BODY = "{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}";
+
+    private BehaviorSubject<Metrics> metricsSubject;
+
+    @BeforeEach
+    void captureMetrics() {
+        metricsSubject = BehaviorSubject.create();
+
+        FakeReporter fakeReporter = getBean(FakeReporter.class);
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Metrics metrics) {
+                metricsSubject.onNext(metrics.toBuilder().build());
+            }
+        });
+    }
+
+    private String postAndReadBody(HttpClient client, String path, String body, int expectedStatus) {
+        return client
+            .rxRequest(POST, path)
+            .map(r ->
+                r
+                    .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .putHeader(HttpHeaderNames.ACCEPT, MediaType.TEXT_PLAIN)
+            )
+            .flatMap(request -> request.rxSend(body))
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                return response.rxBody();
+            })
+            .map(Buffer::toString)
+            .blockingGet();
+    }
+
+    @Test
+    void requestDetailSurfacedInJsonEnvelopeWhenClientAcceptsJson(HttpClient client) throws Exception {
+        String body = client
+            .rxRequest(POST, "/detailed-request")
+            .map(r ->
+                r
+                    .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON)
+            )
+            .flatMap(request -> request.rxSend(INVALID_TYPE_BODY))
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.rxBody();
+            })
+            .map(Buffer::toString)
+            .blockingGet();
+
+        JsonNode envelope = new ObjectMapper().readTree(body);
+        assertThat(envelope.get("http_status_code").asInt()).isEqualTo(400);
+        assertThat(envelope.get("message").asText()).contains(AGE_VIOLATION);
+    }
+
+    @Test
+    void requestDetailEchoesElTokenVerbatim(HttpClient client) {
+        String message = postAndReadBody(client, "/detailed-request-code", "{\"code\":\"${T(java.lang.Runtime)}\"}", 400);
+
+        assertThat(message).contains(CODE_TOO_LONG_VIOLATION);
+    }
+
+    @Test
+    void requestDetailIsNotDoubleEncoded(HttpClient client) {
+        String message = postAndReadBody(client, "/detailed-request", INVALID_TYPE_BODY, 400);
+
+        assertThat(message).contains(AGE_VIOLATION).doesNotContain("{\"message\"").doesNotContain("http_status_code");
+    }
+
+    @Test
+    void perInstanceFlagHonouredIndependently(HttpClient client) {
+        String requestMessage = postAndReadBody(client, "/detailed-per-instance", INVALID_TYPE_BODY, 400);
+        assertThat(requestMessage).contains(AGE_VIOLATION);
+
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+        String responseMessage = client
+            .rxRequest(POST, "/detailed-per-instance")
+            .map(r ->
+                r
+                    .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .putHeader(HttpHeaderNames.ACCEPT, MediaType.TEXT_PLAIN)
+            )
+            .flatMap(request -> request.rxSend(VALID_BODY))
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(500);
+                return response.rxBody();
+            })
+            .map(Buffer::toString)
+            .blockingGet();
+
+        assertThat(responseMessage).isEqualTo("Internal Error");
+    }
+
+    @Test
+    void responseDetailReturnedOnFailingPayload(HttpClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+
+        String message = postAndReadBody(client, "/detailed-response", VALID_BODY, 500);
+
+        assertThat(message).contains(AGE_VIOLATION).contains(EMAIL_VIOLATION);
+    }
+
+    @Test
+    void concurrentRequestsAreIsolated(HttpClient client) throws InterruptedException {
+        String payloadA = "{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"ada@x.io\"}";
+        String payloadB = "{\"name\":\"Bob\",\"age\":7,\"email\":\"x\"}";
+
+        var testA = client
+            .rxRequest(POST, "/detailed-request")
+            .map(r ->
+                r
+                    .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .putHeader(HttpHeaderNames.ACCEPT, MediaType.TEXT_PLAIN)
+            )
+            .flatMap(request -> request.rxSend(payloadA))
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.rxBody();
+            })
+            .map(Buffer::toString)
+            .test();
+        var testB = client
+            .rxRequest(POST, "/detailed-request")
+            .map(r ->
+                r
+                    .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .putHeader(HttpHeaderNames.ACCEPT, MediaType.TEXT_PLAIN)
+            )
+            .flatMap(request -> request.rxSend(payloadB))
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.rxBody();
+            })
+            .map(Buffer::toString)
+            .test();
+
+        testA.await();
+        testB.await();
+
+        String bodyA = testA.values().get(0);
+        String bodyB = testB.values().get(0);
+
+        assertThat(bodyA).contains(AGE_VIOLATION).doesNotContain(EMAIL_VIOLATION);
+        assertThat(bodyB).contains(EMAIL_VIOLATION).doesNotContain(AGE_VIOLATION);
+    }
+
+    @Test
+    void straightRespondModePassesThroughOnFlagOn(HttpClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+
+        String body = postAndReadBody(client, "/straight-respond-flag-on", VALID_BODY, 200);
+
+        assertThat(body).isEqualTo(INVALID_TYPE_BODY);
+    }
+
+    @Test
+    void straightRespondModeRecordsMetricsOnFlagOn(HttpClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+
+        postAndReadBody(client, "/straight-respond-flag-on", VALID_BODY, 200);
+
+        metricsSubject
+            .take(1)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(metrics -> {
+                assertThat(metrics.getErrorMessage())
+                    .isNotBlank()
+                    .contains("instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])")
+                    .contains("string \"x\" is too short (length: 1, required minimum: 5)");
+                return true;
+            });
+    }
+
+    @Test
+    void straightRespondModePassesThroughOnFlagOff(HttpClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+
+        String body = postAndReadBody(client, "/straight-respond-flag-off", VALID_BODY, 200);
+
+        assertThat(body).isEqualTo(INVALID_TYPE_BODY);
+    }
+
+    @Test
+    void straightRespondModeRecordsMetricsOnFlagOff(HttpClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(INVALID_TYPE_BODY)));
+
+        postAndReadBody(client, "/straight-respond-flag-off", VALID_BODY, 200);
+
+        metricsSubject
+            .take(1)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(metrics -> {
+                assertThat(metrics.getErrorMessage())
+                    .isNotBlank()
+                    .contains("instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])")
+                    .contains("string \"x\" is too short (length: 1, required minimum: 5)");
+                return true;
+            });
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+}

--- a/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/JsonValidationPolicyTest.java
@@ -16,19 +16,23 @@
 package io.gravitee.policy.jsonvalidation;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.http.*;
 import io.gravitee.gateway.reactive.api.message.DefaultMessage;
 import io.gravitee.gateway.reactive.api.message.Message;
+import io.gravitee.policy.JsonValidationException;
 import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -60,6 +64,54 @@ class JsonValidationPolicyTest {
             },
             "required": ["name"]
         }""";
+
+    private static final String DETAILED_SCHEMA = """
+        {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "integer" },
+            "email": { "type": "string", "minLength": 5 }
+          },
+          "required": ["name"]
+        }""";
+
+    private static final String DEDUP_SCHEMA = """
+        {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": { "age": { "type": "integer" } },
+          "patternProperties": { "^age$": { "type": "integer" } }
+        }""";
+
+    private static final String UNRESOLVABLE_REF_SCHEMA = """
+        {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "http://nonexistent.invalid/missing.json#" }
+          }
+        }""";
+
+    private static final String NESTED_SCHEMA = """
+        {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "object",
+              "properties": { "street": { "type": "integer" } }
+            }
+          }
+        }""";
+
+    private static final String AGE_VIOLATION =
+        "/age — instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])";
+    private static final String EMAIL_VIOLATION = "/email — string \"x\" is too short (length: 1, required minimum: 5)";
+    private static final String REQUIRED_NAME_VIOLATION = "object has missing required properties ([\"name\"])";
+    private static final String INVALID_DETAILED_PAYLOAD = "{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}";
+    private static final String NON_JSON = "qwerty";
 
     @Mock
     private JsonValidationPolicyConfiguration configuration;
@@ -133,6 +185,21 @@ class JsonValidationPolicyTest {
         }
 
         @Test
+        void badPayloadWithNoConfiguredMessageReturnsGenericBadRequest() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(false);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            assertThat(executionFailureCaptor.getValue().message()).isEqualTo("Bad Request");
+        }
+
+        @Test
         void badBodyIncorrectType() throws IOException {
             // Given
             JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
@@ -169,6 +236,287 @@ class JsonValidationPolicyTest {
 
             verify(ctx).interruptWith(executionFailureCaptor.capture());
             assertThat(executionFailureCaptor.getValue().key()).isEqualTo("JSON_INVALID_PAYLOAD");
+        }
+
+        @Test
+        void badBodyWithDetailedErrorReport_metricsKeepRawReport() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(false);
+            var metricsWithFlagOff = Metrics.builder().build();
+            when(ctx.metrics()).thenReturn(metricsWithFlagOff);
+            JsonValidationPolicy policyFlagOff = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policyFlagOff
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            var metricsWithFlagOn = Metrics.builder().build();
+            when(ctx.metrics()).thenReturn(metricsWithFlagOn);
+            JsonValidationPolicy policyFlagOn = new JsonValidationPolicy(configuration);
+            policyFlagOn
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx, times(2)).interruptWith(executionFailureCaptor.capture());
+            String detailedMessage = executionFailureCaptor.getValue().message();
+            assertThat(metricsWithFlagOn.getErrorMessage()).isNotNull();
+            assertThat(metricsWithFlagOn.getErrorMessage()).isEqualTo(metricsWithFlagOff.getErrorMessage());
+            assertThat(metricsWithFlagOn.getErrorMessage()).isNotEqualTo(detailedMessage);
+        }
+
+        @Test
+        void badBodyWithDetailedErrorReport_errorKeyUnchanged() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(false);
+            JsonValidationPolicy policyFlagOff = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policyFlagOff
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            var failureFlagOff = executionFailureCaptor.getValue();
+
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policyFlagOn = new JsonValidationPolicy(configuration);
+            policyFlagOn
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx, times(2)).interruptWith(executionFailureCaptor.capture());
+            var failureFlagOn = executionFailureCaptor.getValue();
+            assertThat(failureFlagOn.key()).isEqualTo("JSON_INVALID_PAYLOAD");
+            assertThat(failureFlagOff.key()).isEqualTo("JSON_INVALID_PAYLOAD");
+        }
+
+        @Test
+        void badBodyWithDetailedErrorReport_keyAndStatusUnchanged() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            var failure = executionFailureCaptor.getValue();
+            assertThat(failure.key()).isEqualTo("JSON_INVALID_PAYLOAD");
+            assertThat(failure.statusCode()).isEqualTo(400);
+        }
+
+        private String detailedMessageFor(String body) throws IOException {
+            return detailedMessageForSchema(DETAILED_SCHEMA, body);
+        }
+
+        private String detailedMessageForSchema(String schema, String body) throws IOException {
+            when(configuration.getSchema()).thenReturn(schema);
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer(body)));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            return executionFailureCaptor.getValue().message();
+        }
+
+        @Test
+        void detailReportsAllSiblingViolationsIncludingRequired() throws IOException {
+            String message = detailedMessageFor("{\"age\":\"twenty\",\"email\":\"x\"}");
+
+            assertThat(message).contains(REQUIRED_NAME_VIOLATION);
+            assertThat(message).contains(AGE_VIOLATION);
+            assertThat(message).contains(EMAIL_VIOLATION);
+        }
+
+        @Test
+        void detailIsNotGenericWhenNoConfiguredMessage() throws IOException {
+            String message = detailedMessageFor("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+
+            assertThat(message).doesNotContain("Bad Request");
+            assertThat(message).contains(AGE_VIOLATION);
+        }
+
+        @Test
+        void detailedReportBypassesSpelInConfiguredMessage() throws IOException {
+            lenient().when(configuration.getErrorMessage()).thenReturn("{#request.headers['x-test']}");
+            String message = detailedMessageFor("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+
+            assertThat(message).contains(AGE_VIOLATION);
+            assertThat(message).doesNotContain("{#request.headers['x-test']}");
+            verify(ctx, never()).getTemplateEngine();
+        }
+
+        @Test
+        void flagOffEvaluatesSpelInConfiguredMessage() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(false);
+            when(configuration.getErrorMessage()).thenReturn("{#request.headers['x-test']}");
+            TemplateEngine templateEngine = mock(TemplateEngine.class);
+            when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+            when(templateEngine.eval("{#request.headers['x-test']}", String.class)).thenReturn(Maybe.just("my-value"));
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            verify(templateEngine).eval("{#request.headers['x-test']}", String.class);
+            var failure = executionFailureCaptor.getValue();
+            assertThat(failure.message()).contains("my-value");
+            assertThat(failure.message()).doesNotContain("{#request.headers");
+        }
+
+        @Test
+        void spelEvalFailureFallsBackToGenericBadRequest() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(false);
+            when(configuration.getErrorMessage()).thenReturn("{#request.headers['x-test']}");
+            TemplateEngine templateEngine = mock(TemplateEngine.class);
+            when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+            when(templateEngine.eval("{#request.headers['x-test']}", String.class)).thenReturn(
+                Maybe.error(new RuntimeException("SpEL eval failed"))
+            );
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            assertThat(executionFailureCaptor.getValue().message()).isEqualTo("Bad Request");
+        }
+
+        @Test
+        void detailRendersNestedPointer() throws IOException {
+            String message = detailedMessageForSchema(NESTED_SCHEMA, "{\"address\":{\"street\":\"not-an-int\"}}");
+
+            assertThat(message).contains("/address/street");
+        }
+
+        @Test
+        void deduplicationPreventsDuplicateViolationLines() throws IOException {
+            String message = detailedMessageForSchema(DEDUP_SCHEMA, "{\"age\":\"twenty\"}");
+
+            int occurrences = message.split(Pattern.quote(AGE_VIOLATION), -1).length - 1;
+            assertThat(occurrences).isEqualTo(1);
+        }
+
+        @Test
+        void validateUncheckedSurfacesSchemaAnomalyInDetailedReport() throws IOException {
+            when(configuration.getSchema()).thenReturn(UNRESOLVABLE_REF_SCHEMA);
+            when(configuration.isValidateUnchecked()).thenReturn(true);
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name\":\"foo\"}")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            var failure = executionFailureCaptor.getValue();
+            assertThat(failure.key()).isEqualTo("JSON_INVALID_PAYLOAD");
+            assertThat(failure.statusCode()).isEqualTo(400);
+            assertThat(failure.message())
+                .doesNotContain("Bad Request")
+                .contains("unable to dereference URI \"http://nonexistent.invalid/missing.json#\"");
+        }
+
+        @Test
+        void nonJsonIsGenericFormatWithoutDetailEvenWhenDetailEnabled() throws IOException {
+            lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("not json")));
+
+            policy
+                .onRequest(ctx)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptWith(executionFailureCaptor.capture());
+            var failure = executionFailureCaptor.getValue();
+            assertThat(failure.key()).isEqualTo("JSON_INVALID_FORMAT");
+            assertThat(failure.message()).isEqualTo("Bad Request");
+        }
+
+        @Test
+        void runtimeExceptionInDetailBuildingProducesGracefulErrorAndLogsAtError() throws IOException {
+            when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration) {
+                @Override
+                protected java.util.Optional<String> buildDetailedMessage(
+                    com.fasterxml.jackson.databind.JsonNode schema,
+                    com.fasterxml.jackson.databind.JsonNode content
+                ) {
+                    throw new RuntimeException("injected");
+                }
+            };
+            when(request.body()).thenReturn(Maybe.just(Buffer.buffer("{\"name2\":\"foo\"}")));
+
+            ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(
+                JsonValidationPolicy.class
+            );
+            ch.qos.logback.classic.Level originalLevel = logger.getLevel();
+            ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+                new ch.qos.logback.core.read.ListAppender<>();
+            appender.start();
+            logger.addAppender(appender);
+            logger.setLevel(ch.qos.logback.classic.Level.ERROR);
+            try {
+                policy
+                    .onRequest(ctx)
+                    .test()
+                    .assertError(throwable -> throwable instanceof MyCustomException);
+
+                verify(ctx).interruptWith(executionFailureCaptor.capture());
+                assertThat(executionFailureCaptor.getValue().statusCode()).isEqualTo(400);
+                org.assertj.core.api.Assertions.assertThat(appender.list).anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.ERROR);
+                    assertThat(event.getFormattedMessage()).contains("Unexpected error during JSON validation");
+                });
+            } finally {
+                logger.setLevel(originalLevel);
+                logger.detachAppender(appender);
+                appender.stop();
+            }
+        }
+
+        @Test
+        void detailedReportIsCappedWhenMoreThanFiftyElementsFail() throws IOException {
+            String arrayOfIntegersSchema = """
+                {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "type": "array",
+                  "items": { "type": "integer" }
+                }""";
+            StringBuilder payload = new StringBuilder("[");
+            for (int i = 0; i < 100; i++) {
+                if (i > 0) payload.append(", ");
+                payload.append("\"item").append(i).append("\"");
+            }
+            payload.append("]");
+
+            String message = detailedMessageForSchema(arrayOfIntegersSchema, payload.toString());
+
+            long violationCount = message
+                .chars()
+                .filter(c -> c == '—')
+                .count();
+            assertThat(violationCount).isLessThanOrEqualTo(50);
         }
     }
 
@@ -220,6 +568,49 @@ class JsonValidationPolicyTest {
             verify(ctx).interruptMessageWith(executionFailureCaptor.capture());
             assertThat(executionFailureCaptor.getValue().key()).isEqualTo("JSON_INVALID_MESSAGE_REQUEST_PAYLOAD");
         }
+
+        private ExecutionFailure messageFailureFor(String body) throws IOException {
+            when(configuration.getSchema()).thenReturn(DETAILED_SCHEMA);
+            lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            lenient().when(ctx.metrics()).thenReturn(Metrics.builder().build());
+            when(ctx.interruptMessageWith(any())).thenReturn(Maybe.error(new MyCustomException()));
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer(body)).build();
+
+            policy.onMessageRequest(ctx).test().assertComplete();
+            verify(request).onMessage(messageCaptor.capture());
+            messageCaptor
+                .getValue()
+                .apply(message)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptMessageWith(executionFailureCaptor.capture());
+            return executionFailureCaptor.getValue();
+        }
+
+        @Test
+        void messageRequestPayloadFailureCarriesDetail() throws IOException {
+            var failure = messageFailureFor(INVALID_DETAILED_PAYLOAD);
+
+            assertThat(failure.statusCode()).isEqualTo(400);
+            assertThat(failure.key()).isEqualTo("JSON_INVALID_MESSAGE_REQUEST_PAYLOAD");
+            assertThat(failure.message()).contains(AGE_VIOLATION);
+            assertThat(failure.message()).contains(EMAIL_VIOLATION);
+        }
+
+        @Test
+        void messageRequestFormatErrorThrowsJsonValidationException() throws IOException {
+            when(configuration.getSchema()).thenReturn(DETAILED_SCHEMA);
+            lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer(NON_JSON)).build();
+
+            policy.onMessageRequest(ctx).test().assertComplete();
+            verify(request).onMessage(messageCaptor.capture());
+
+            assertThatThrownBy(() -> messageCaptor.getValue().apply(message)).isInstanceOf(JsonValidationException.class);
+        }
     }
 
     @Nested
@@ -269,6 +660,49 @@ class JsonValidationPolicyTest {
 
             verify(ctx).interruptMessageWith(executionFailureCaptor.capture());
             assertThat(executionFailureCaptor.getValue().key()).isEqualTo("JSON_INVALID_MESSAGE_RESPONSE_PAYLOAD");
+        }
+
+        private ExecutionFailure messageFailureFor(String body) throws IOException {
+            when(configuration.getSchema()).thenReturn(DETAILED_SCHEMA);
+            lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            lenient().when(ctx.metrics()).thenReturn(Metrics.builder().build());
+            when(ctx.interruptMessageWith(any())).thenReturn(Maybe.error(new MyCustomException()));
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer(body)).build();
+
+            policy.onMessageResponse(ctx).test().assertComplete();
+            verify(response).onMessage(messageCaptor.capture());
+            messageCaptor
+                .getValue()
+                .apply(message)
+                .test()
+                .assertError(throwable -> throwable instanceof MyCustomException);
+
+            verify(ctx).interruptMessageWith(executionFailureCaptor.capture());
+            return executionFailureCaptor.getValue();
+        }
+
+        @Test
+        void messageResponsePayloadFailureCarriesDetail() throws IOException {
+            var failure = messageFailureFor(INVALID_DETAILED_PAYLOAD);
+
+            assertThat(failure.statusCode()).isEqualTo(400);
+            assertThat(failure.key()).isEqualTo("JSON_INVALID_MESSAGE_RESPONSE_PAYLOAD");
+            assertThat(failure.message()).contains(AGE_VIOLATION);
+            assertThat(failure.message()).contains(EMAIL_VIOLATION);
+        }
+
+        @Test
+        void messageResponseFormatErrorThrowsJsonValidationException() throws IOException {
+            when(configuration.getSchema()).thenReturn(DETAILED_SCHEMA);
+            lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+            JsonValidationPolicy policy = new JsonValidationPolicy(configuration);
+            DefaultMessage message = DefaultMessage.builder().id("id").content(Buffer.buffer(NON_JSON)).build();
+
+            policy.onMessageResponse(ctx).test().assertComplete();
+            verify(response).onMessage(messageCaptor.capture());
+
+            assertThatThrownBy(() -> messageCaptor.getValue().apply(message)).isInstanceOf(JsonValidationException.class);
         }
     }
 

--- a/src/test/java/io/gravitee/policy/jsonvalidation/swagger/JsonValidationOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/jsonvalidation/swagger/JsonValidationOAIOperationVisitorTest.java
@@ -196,7 +196,8 @@ class JsonValidationOAIOperationVisitorTest {
                   "schema" : "{\\n  \\"type\\" : [ \\"integer\\", \\"null\\" ],\\n  \\"description\\" : \\"The age of the pet in months. Can be null if the age is unknown.\\",\\n  \\"title\\" : \\"PetAge\\"\\n}",
                   "validateUnchecked" : false,
                   "deepCheck" : false,
-                  "straightRespondMode" : false
+                  "straightRespondMode" : false,
+                  "returnDetailedErrorReport" : false
                 }"""
             );
         }

--- a/src/test/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jsonvalidation/JsonValidationPolicyV3Test.java
@@ -16,9 +16,17 @@
 package io.gravitee.policy.v3.jsonvalidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jackson.JsonLoader;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
 import io.gravitee.common.util.ServiceLoaderHelper;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
@@ -34,14 +42,24 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.jsonvalidation.configuration.JsonValidationPolicyConfiguration;
 import io.gravitee.policy.jsonvalidation.configuration.PolicyScope;
 import io.gravitee.reporter.api.http.Metrics;
+import io.reactivex.rxjava3.core.Maybe;
+import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonValidationPolicyV3Test {
@@ -75,6 +93,100 @@ public class JsonValidationPolicyV3Test {
             "required": ["name"]
         }""";
 
+    private static final String TYPED_PERSON_SCHEMA = """
+        {
+            "title": "Person",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string",
+                    "minLength": 5
+                }
+            },
+            "required": ["name", "age", "email"]
+        }""";
+
+    private static final String NESTED_PERSON_SCHEMA = """
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "child": {
+                    "type": "object",
+                    "properties": {
+                        "age": {
+                            "type": "integer"
+                        },
+                        "email": {
+                            "type": "string",
+                            "minLength": 5
+                        }
+                    }
+                }
+            },
+            "required": ["name"]
+        }""";
+
+    private static final String DEEP_REF_BREAKING_SCHEMA = """
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "child": {
+                    "$ref": "#/definitions/Missing"
+                }
+            },
+            "required": ["name"]
+        }""";
+
+    private static final String SLASH_KEY_SCHEMA = """
+        {
+            "type": "object",
+            "properties": {
+                "a/b": {
+                    "type": "integer"
+                }
+            }
+        }""";
+
+    private static final String TILDE_KEY_SCHEMA = """
+        {
+            "type": "object",
+            "properties": {
+                "a~b": {
+                    "type": "integer"
+                }
+            }
+        }""";
+
+    private static final String ARRAY_ITEMS_SCHEMA = """
+        {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }""";
+
+    private static final String AGE_TYPE_VIOLATION =
+        "/age — instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])";
+
+    private static final String EMAIL_MINLENGTH_VIOLATION = "/email — string \"x\" is too short (length: 1, required minimum: 5)";
+
     private Metrics metrics;
 
     @InjectMocks
@@ -85,8 +197,8 @@ public class JsonValidationPolicyV3Test {
         factory = ServiceLoaderHelper.loadFactory(BufferFactory.class);
         metrics = Metrics.on(System.currentTimeMillis()).build();
 
-        when(configuration.getSchema()).thenReturn(JSON_SCHEMA);
-        lenient().when(configuration.getErrorMessage()).thenReturn("{\"msg\":\"error\"}");
+        lenient().when(configuration.getSchema()).thenReturn(JSON_SCHEMA);
+        lenient().when(configuration.getErrorMessage()).thenReturn("custom error");
         lenient().when(mockRequest.metrics()).thenReturn(metrics);
         lenient().when(mockExecutionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());
     }
@@ -261,6 +373,383 @@ public class JsonValidationPolicyV3Test {
         policyAssertions();
     }
 
+    @Test
+    void shouldReportPerFieldDetailOnRequestPayloadFailureWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+    }
+
+    @ParameterizedTest
+    @MethodSource("rfc6901PointerCases")
+    void shouldEncodePointerPerRfc6901OnRequestPayloadFailureWhenFlagOn(String schema, String payload, String expectedPointerFragment) {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(schema);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer(payload);
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(value.message()).contains(expectedPointerFragment);
+    }
+
+    static Stream<Arguments> rfc6901PointerCases() {
+        return Stream.of(
+            Arguments.of(SLASH_KEY_SCHEMA, "{\"a/b\":\"x\"}", "/a~1b — "),
+            Arguments.of(TILDE_KEY_SCHEMA, "{\"a~b\":\"x\"}", "/a~0b — "),
+            Arguments.of(ARRAY_ITEMS_SCHEMA, "{\"items\":[1,\"x\",3]}", "/items/1 — ")
+        );
+    }
+
+    @Test
+    void shouldReportPerFieldDetailOnRequestPayloadFailureWhenUncheckedFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        when(configuration.isValidateUnchecked()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+    }
+
+    @Test
+    void shouldReportAllViolationsInDetailPathRegardlessOfConfiguredDeepCheckFlag() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        when(configuration.isDeepCheck()).thenReturn(false);
+
+        Buffer buffer = factory.buffer("{\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).contains("name").contains("required").contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+    }
+
+    @Test
+    void shouldNotEvaluateSpelErrorMessageOnDetailPathWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        lenient().when(configuration.getErrorMessage()).thenReturn("{\"msg\":\"${request.id}\"}");
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+        assertThat(value.message()).doesNotContain("request.id").doesNotContain("${");
+    }
+
+    @Test
+    void shouldPreferDetailOverConfiguredErrorMessageWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        when(configuration.getErrorMessage()).thenReturn("{\"msg\":\"configured\"}");
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+        assertThat(value.message()).doesNotContain("configured");
+    }
+
+    @Test
+    void shouldReportPerFieldDetailOnResponsePayloadFailureWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onResponseContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_RESPONSE_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldPassThroughResponseInStraightModeRegardlessOfDetailFlag(boolean flagOn) {
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isStraightRespondMode()).thenReturn(true);
+        lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(flagOn);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onResponseContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isTrue();
+        assertThat(metrics.getMessage()).contains("instance type").contains("/age");
+        verify(mockPolicychain, times(0)).streamFailWith(any());
+    }
+
+    @Test
+    void shouldUseGenericMessageOnRequestFormatFailureWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.getErrorMessage()).thenReturn(null);
+        lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_FORMAT_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.message()).isEqualTo(JsonValidationPolicyV3.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldFallBackToGenericMessageWhenDetailBuildThrowsProcessingException() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(DEEP_REF_BREAKING_SCHEMA);
+        when(configuration.getErrorMessage()).thenReturn(null);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(JsonValidationPolicyV3.class);
+        Level originalLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        try {
+            Buffer buffer = factory.buffer("{\"child\":{}}");
+            var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+            readWriteStream.write(buffer);
+            readWriteStream.end();
+
+            PolicyResult value = captureFailure();
+            assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+            assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            assertThat(value.message()).isEqualTo(JsonValidationPolicyV3.BAD_REQUEST);
+            assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+            assertThat(appender.list).anySatisfy(event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getFormattedMessage()).contains("Detailed validation report generation failed");
+            });
+        } finally {
+            logger.setLevel(originalLevel);
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @Test
+    void shouldSurfaceSchemaAnomalyDetailWhenUncheckedAndBrokenSchemaAndFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(DEEP_REF_BREAKING_SCHEMA);
+        when(configuration.getErrorMessage()).thenReturn(null);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        when(configuration.isValidateUnchecked()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"child\":{}}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(value.message()).isEqualTo(
+            "(root) — JSON Reference \"#/definitions/Missing\" cannot be resolved; (root) — object has missing required properties ([\"name\"])"
+        );
+        assertThat(value.message()).isNotEqualTo(JsonValidationPolicyV3.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldLabelRootPointerWhenRootPropertyViolationAndFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(JSON_SCHEMA);
+        when(configuration.getErrorMessage()).thenReturn(null);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).isEqualTo("(root) — object has missing required properties ([\"name\"])");
+    }
+
+    @Test
+    void shouldUseGenericMessageOnResponseFormatFailureWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
+        when(configuration.getSchema()).thenReturn("\"msg\":\"error\"}");
+        when(configuration.getErrorMessage()).thenReturn(null);
+        lenient().when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":\"foo\"}");
+        var readWriteStream = policy.onResponseContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_RESPONSE_FORMAT_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        assertThat(value.message()).isEqualTo(JsonValidationPolicyV3.INTERNAL_ERROR);
+    }
+
+    @Test
+    void shouldKeepMetricsMessageDistinctFromConsumerDetailWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).contains(AGE_TYPE_VIOLATION).contains(EMAIL_MINLENGTH_VIOLATION);
+        assertThat(metrics.getMessage()).contains("instance type").contains("/age");
+        assertThat(metrics.getMessage()).isNotEqualTo(value.message());
+    }
+
+    @Test
+    void shouldRecordMetricsUsingConfiguredDeepCheckWhenFlagOn() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(NESTED_PERSON_SCHEMA);
+        when(configuration.isReturnDetailedErrorReport()).thenReturn(true);
+        when(configuration.isDeepCheck()).thenReturn(true);
+
+        Buffer buffer = factory.buffer("{\"child\":{\"age\":\"twenty\",\"email\":\"x\"}}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        captureFailure();
+        assertThat(metrics.getMessage()).contains("/child/age").contains("/child/email");
+    }
+
+    @Test
+    void shouldKeepConfiguredErrorMessageOnRequestPayloadFailureWhenFlagOff() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).isEqualTo("custom error");
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    void shouldEvaluateSpelInConfiguredErrorMessageWhenFlagOff() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        var templateEngine = mock(TemplateEngine.class);
+        when(mockExecutionContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(configuration.getErrorMessage()).thenReturn("{\"msg\":\"${ctx.attribute}\"}");
+        when(templateEngine.eval("{\"msg\":\"${ctx.attribute}\"}", String.class)).thenReturn(Maybe.just("{\"msg\":\"evaluated\"}"));
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).isEqualTo("{\"msg\":\"evaluated\"}");
+        assertThat(value.message()).doesNotContain("${ctx.attribute}");
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    @Test
+    void shouldUseBadRequestTextPlainWhenNoErrorMessageAndFlagOff() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        when(configuration.getErrorMessage()).thenReturn(null);
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.message()).isEqualTo("Bad Request");
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    @Test
+    void shouldFailStreamWhenSpelErrorMessageEvaluationFails() {
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
+        when(configuration.getSchema()).thenReturn(TYPED_PERSON_SCHEMA);
+        var templateEngine = mock(TemplateEngine.class);
+        when(mockExecutionContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(configuration.getErrorMessage()).thenReturn("{\"msg\":\"${ctx.broken}\"}");
+        when(templateEngine.eval("{\"msg\":\"${ctx.broken}\"}", String.class)).thenReturn(
+            Maybe.error(new RuntimeException("SpEL evaluation failed"))
+        );
+
+        Buffer buffer = factory.buffer("{\"name\":\"Ada\",\"age\":\"twenty\",\"email\":\"x\"}");
+        var readWriteStream = policy.onRequestContent(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+        readWriteStream.write(buffer);
+        readWriteStream.end();
+
+        PolicyResult value = captureFailure();
+        assertThat(value.key()).isEqualTo(JsonValidationPolicyV3.JSON_INVALID_PAYLOAD_KEY);
+        assertThat(value.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(value.message()).isEqualTo(JsonValidationPolicyV3.BAD_REQUEST);
+        assertThat(value.contentType()).isEqualTo(MediaType.TEXT_PLAIN);
+    }
+
+    private PolicyResult captureFailure() {
+        ArgumentCaptor<PolicyResult> policyResult = ArgumentCaptor.forClass(PolicyResult.class);
+        verify(mockPolicychain, times(1)).streamFailWith(policyResult.capture());
+        return policyResult.getValue();
+    }
+
     private void policyAssertions() {
         assertThat(metrics.getMessage()).isNotEmpty();
         ArgumentCaptor<PolicyResult> policyResult = ArgumentCaptor.forClass(PolicyResult.class);
@@ -276,7 +765,7 @@ public class JsonValidationPolicyV3Test {
         ArgumentCaptor<PolicyResult> policyResult = ArgumentCaptor.forClass(PolicyResult.class);
         verify(mockPolicychain, times(1)).streamFailWith(policyResult.capture());
         PolicyResult value = policyResult.getValue();
-        assertThat(value.message()).isEqualTo(configuration.getErrorMessage());
+        assertThat(value.message()).isEqualTo("custom error");
         assertThat(value.statusCode()).isEqualTo(statusCode);
         assertThat(value.key()).isEqualTo(key);
     }
@@ -292,5 +781,26 @@ public class JsonValidationPolicyV3Test {
         final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = new AtomicBoolean(false);
         readWriteStream.endHandler(__ -> hasCalledEndOnReadWriteStreamParentClass.set(true));
         return hasCalledEndOnReadWriteStreamParentClass;
+    }
+
+    @Nested
+    class BuildDetailedMessageTest {
+
+        @Test
+        void emptyDeepReportCollapsesToEmptyOptional() throws IOException {
+            JsonNode parsedSchema = JsonLoader.fromString("{}");
+            JsonNode jsonNode = JsonLoader.fromString("{\"name\":\"Ada\"}");
+
+            Optional<String> detailedMessage = policy.buildDetailedMessage(parsedSchema, jsonNode);
+
+            assertThat(detailedMessage).isEmpty();
+        }
+
+        @Test
+        void unexpectedRuntimeExceptionPropagatesInsteadOfBecomingEmptyOptional() throws IOException {
+            JsonNode parsedSchema = JsonLoader.fromString(JSON_SCHEMA);
+
+            assertThatThrownBy(() -> policy.buildDetailedMessage(parsedSchema, null)).isInstanceOf(RuntimeException.class);
+        }
     }
 }

--- a/src/test/resources/apis/v4-detailed-per-instance.json
+++ b/src/test/resources/apis/v4-detailed-per-instance.json
@@ -1,0 +1,82 @@
+{
+    "id": "v4-detailed-per-instance",
+    "name": "v4-detailed-per-instance",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {},
+    "description": "request policy flag on, response policy flag off",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/detailed-per-instance"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "Json validation request",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "returnDetailedErrorReport": true,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "response": [
+                {
+                    "name": "Json validation response",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "RESPONSE_CONTENT",
+                        "returnDetailedErrorReport": false,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}

--- a/src/test/resources/apis/v4-detailed-request-code.json
+++ b/src/test/resources/apis/v4-detailed-request-code.json
@@ -1,0 +1,70 @@
+{
+    "id": "v4-detailed-request-code",
+    "name": "v4-detailed-request-code",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {},
+    "description": "request-phase code maxLength schema for EL-literal",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/detailed-request-code"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "Json validation",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "returnDetailedErrorReport": true,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"code\": { \"type\": \"string\", \"maxLength\": 3 }\n  },\n  \"required\": [\"code\"]\n}"
+                    }
+                }
+            ],
+            "response": [],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}

--- a/src/test/resources/apis/v4-detailed-request.json
+++ b/src/test/resources/apis/v4-detailed-request.json
@@ -1,0 +1,70 @@
+{
+    "id": "v4-detailed-request",
+    "name": "v4-detailed-request",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {},
+    "description": "request-phase detailed error report",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/detailed-request"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "Json validation",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "returnDetailedErrorReport": true,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "response": [],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}

--- a/src/test/resources/apis/v4-detailed-response.json
+++ b/src/test/resources/apis/v4-detailed-response.json
@@ -1,0 +1,70 @@
+{
+    "id": "v4-detailed-response",
+    "name": "v4-detailed-response",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {},
+    "description": "response-phase detailed error report",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/detailed-response"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [],
+            "response": [
+                {
+                    "name": "Json validation",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "RESPONSE_CONTENT",
+                        "returnDetailedErrorReport": true,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}

--- a/src/test/resources/apis/v4-straight-respond-flag-off.json
+++ b/src/test/resources/apis/v4-straight-respond-flag-off.json
@@ -1,0 +1,73 @@
+{
+    "id": "v4-straight-respond-flag-off",
+    "name": "v4-straight-respond-flag-off",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {
+        "enabled": true
+    },
+    "description": "response-phase straightRespondMode with returnDetailedErrorReport off",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/straight-respond-flag-off"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [],
+            "response": [
+                {
+                    "name": "Json validation response",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "RESPONSE_CONTENT",
+                        "straightRespondMode": true,
+                        "returnDetailedErrorReport": false,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}

--- a/src/test/resources/apis/v4-straight-respond-flag-on.json
+++ b/src/test/resources/apis/v4-straight-respond-flag-on.json
@@ -1,0 +1,73 @@
+{
+    "id": "v4-straight-respond-flag-on",
+    "name": "v4-straight-respond-flag-on",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {
+        "enabled": true
+    },
+    "description": "response-phase straightRespondMode with returnDetailedErrorReport on",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/straight-respond-flag-on"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/team"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [],
+            "response": [
+                {
+                    "name": "Json validation response",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "json-validation",
+                    "configuration": {
+                        "scope": "RESPONSE_CONTENT",
+                        "straightRespondMode": true,
+                        "returnDetailedErrorReport": true,
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": { \"type\": \"string\" },\n    \"age\": { \"type\": \"integer\" },\n    \"email\": { \"type\": \"string\", \"minLength\": 5 }\n  },\n  \"required\": [\"name\"]\n}"
+                    }
+                }
+            ],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}


### PR DESCRIPTION
## Purpose

Callers debugging a failed JSON Schema validation currently only get the configured generic `errorMessage`, with no indication of which field(s) failed or why. This adds an opt-in flag that returns the actual per-violation validation detail instead, to speed up client-side debugging without requiring server logs.

## Summary of changes

- Adds a new boolean config flag `returnDetailedErrorReport` (default `false`) to `JsonValidationPolicyConfiguration`, exposed on the `json-validation` policy config schema (`schema-form.json`).
- When `true` and not in `straightRespondMode`, a failed JSON Schema validation returns a per-violation detail body — one line per violation, formatted `"<pointer> — <message>"`, deduplicated (insertion order), capped at 50 entries, joined with `"; "` — instead of evaluating the configured `errorMessage` (SpEL is skipped entirely in this mode).
- When `false`/absent, behavior is unchanged from the existing `errorMessage` path, including SpEL evaluation and its eval-failure fallback.
- Implemented in both engines: the V3 legacy engine (`JsonValidationPolicyV3`, `REQUEST_CONTENT`/`RESPONSE_CONTENT`) and the V4 reactive engine (`JsonValidationPolicy`, `onRequest`/`onResponse`/`onMessageRequest`/`onMessageResponse`).
- The policy always calls `ctx.metrics().setErrorMessage(rawReport)` with the raw schema-validator report immediately before responding. On non-`straightRespondMode` paths this is subsequently superseded by the client-facing message — a V4 gateway-core constraint outside this plugin's control (see Known Issues).
- `straightRespondMode` (response scope only) makes the flag inert: a failed response still passes through unchanged, and the raw failure is recorded to metrics untouched (the one path where the gateway-core overwrite described above never triggers), but no detail is ever injected.
- Detail-generation failures (e.g. an unresolvable schema `$ref`, or a detail that assembles to blank) fall back cleanly to the existing `errorMessage`/generic error path.

### Behaviour changes

- New opt-in response body shape for validation failures when `returnDetailedErrorReport=true`: the response body becomes the raw per-violation detail string instead of the configured `errorMessage`.
- ⚠️ Info-leak note (also documented in the config schema description): enabling the flag exposes JSON Schema field names/structure to callers — should stay disabled in production unless callers are trusted.

## Testing

Full manual regression pass against a local APIM 4.9.x gateway. **35/35 test cases passed.** All error responses on this 2.2.x-based branch are plain text (`Content-Type: text/plain`) in both flag-on and flag-off modes — there is no JSON envelope on this baseline.

| TC | Summary | Status |
|---|---|---|
| TC-001 | Multi-violation request body returns detail report (V4 `onRequest`) | PASS |
| TC-002 | Single-violation request body (non-root pointer) | PASS |
| TC-003 | Root-level violation renders as `(root) — ...` | PASS |
| TC-004 | Valid request body passes through untouched | PASS |
| TC-005 | Detail body not double-encoded; EL-look-alike values never evaluated | PASS |
| TC-006 | V3 legacy engine parity with V4 | PASS |
| TC-007 | Invalid upstream response returns detail body with swapped key | PASS |
| TC-008 | Response detail leaks schema field names (documented info-leak) | PASS |
| TC-009 | Response-template override on documented key doesn't fire (key-swap consequence) | PASS |
| TC-010 | `onMessageRequest`: invalid published message interrupted with detail | PASS |
| TC-011 | `onMessageResponse`: invalid subscribed message interrupted with detail | PASS |
| TC-012 | Valid message passes through untouched on both message scopes | PASS |
| TC-013 | straightRespondMode ON + flag ON: pass-through unchanged, no detail | PASS |
| TC-014 | straightRespondMode ON + flag OFF: identical pass-through (flag is inert) | PASS |
| TC-015 | straightRespondMode still records raw failure to metrics (flag ON) | PASS |
| TC-016 | straightRespondMode still records raw failure to metrics (flag OFF) | PASS |
| TC-017 | Duplicate violations collapse via insertion-ordered dedup | PASS |
| TC-018 | Cap counts messages processed, not unique entries (heavy-duplicate variant) | PASS |
| TC-019 | Truncation at 50 for a >50-unique-violation payload | PASS |
| TC-020 | Unresolvable `$ref`, `validateUnchecked=false`: clean fallback, no crash | PASS |
| TC-021 | Unresolvable `$ref`, `validateUnchecked=true`: masked into report, no crash | PASS |
| TC-022 | Request instance (flag ON) returns detail; response instance (flag OFF) doesn't | PASS |
| TC-023 | Concurrent requests through one instance isolated (no cross-request bleed) | PASS |
| TC-024 | Concurrent load across both instances shows no cross-instance bleed | PASS |
| TC-025 | Request scope, malformed (non-JSON) body → format key | PASS |
| TC-026 | Request scope, schema-valid-but-failing body → payload key (cross-ref TC-001) | PASS |
| TC-027 | Response scope, malformed (non-JSON) backend body → observed swapped key `JSON_INVALID_RESPONSE_PAYLOAD` | PASS |
| TC-028 | Content-Type is `text/plain` uniformly across every scope/key (summary check) | PASS |
| TC-032 | Literal configured `errorMessage` returned verbatim, not parsed as JSON | PASS |
| TC-033 | SpEL `errorMessage` is evaluated, not echoed as literal token | PASS |
| TC-034 | SpEL evaluation failure falls back to generic message | PASS |
| TC-035 | No configured `errorMessage` falls back to generic message | PASS |
| TC-036 | Content-Type is `text/plain` on every flag-off branch (recap) | PASS |
| TC-037 | Flag absent from config defaults to `false` (legacy behavior) | PASS |
| TC-038 | API Console form renders flag with default `false` and info-leak warning | PASS |

Three additional test cases (former TC-029–031, covering raw-report metrics independent of the client-facing message) were dropped from scope — see Known Issues.

## Known Issues

- Metrics diagnostic message is overwritten by the client-facing string on non-`straightRespondMode` paths. Root cause confirmed by source inspection: V4 gateway-core's `AbstractExecutionContext.interruptWith` (`gravitee-apim-gateway-core`) unconditionally rebuilds the diagnostic via `DiagnosticReportHelper.fromExecutionFailure`, preferring `ExecutionFailure.message()` (the client-facing string) over the policy's raw report whenever the `ExecutionFailure` has a non-null message — which `json-validation` always supplies on non-straight-respond paths. `ExecutionFailure` (`gravitee-gateway-api`) has only one `message` field, used for both the response body and the diagnostic, with no way to decouple them. This affects any V4 policy calling `interruptWith` with a message, not just `json-validation` — it is a platform-wide constraint, not a defect in this plugin. Recommend tracking separately against `gravitee-apim-gateway-core`/`gravitee-gateway-api` if raw-report metrics visibility is desired.

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.2.0/gravitee-policy-json-validation-2.2.0.zip)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-andres-osorio-revert-3-0-0-features-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-validation/2.2.0-andres-osorio-revert-3-0-0-features-SNAPSHOT/gravitee-policy-json-validation-2.2.0-andres-osorio-revert-3-0-0-features-SNAPSHOT.zip)
  <!-- Version placeholder end -->
